### PR TITLE
allow users not to use MYSQL_USER, MYSQL_USER_PWD and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ to run in non-root mode. That way you only need to specify the
 values at runtime and pass the `-u mysql` if need be. (run `id`
 in your terminal to see your own `PUID`/`PGID` values.)
 
-Configurations are located at `/etc/mysql` and the data at
+Configurations are located at `/etc/my.cnf`, `/etc/my.cnf.d/*` and the data at
 `/var/lib/mysql`. The default `my.cnf` is provided, replace the
 file or rebind the whole directory with your configs. Otherwise
 the environment variables `MYSQL_ROOT_PWD` `MYSQL_USER`

--- a/root/etc/cont-init.d/10-setup
+++ b/root/etc/cont-init.d/10-setup
@@ -2,8 +2,8 @@
 
 # parameters
 MYSQL_ROOT_PWD=${MYSQL_ROOT_PWD:-"mysqlrootpassword"}
-MYSQL_USER=${MYSQL_USER:-"mysql"}
-MYSQL_USER_PWD=${MYSQL_USER_PWD:-"mysqlpassword"}
+MYSQL_USER=${MYSQL_USER}
+MYSQL_USER_PWD=${MYSQL_USER_PWD}
 MYSQL_USER_DB=${MYSQL_USER_DB:-"test"}
 
 if [ ! -d "/run/mysqld" ]; then


### PR DESCRIPTION
- update README.md
  - related to https://github.com/woahbase/alpine-mysql/commit/10969a1b3e17bb301f99472f3206f5157af96e23
- allow users not to use MYSQL_USER, MYSQL_USER_PWD
  - Isn't it better not to set MYSQL_USER, MYSQL_USER_PWD when there is no related environment variables?